### PR TITLE
Improve Task Result Handling and Add File Filtering by Data Type, MIME Type, and Filename

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,6 +65,8 @@ class Utils(unittest.TestCase):
             "workflow_id": workflow_id,
             "command": command,
             "meta": meta,
+            "file_reports": [],
+            "task_report": None,
         }
 
         result = utils.task_result(
@@ -72,6 +74,8 @@ class Utils(unittest.TestCase):
             workflow_id=workflow_id,
             command=command,
             meta=meta,
+            file_reports=[],
+            task_report=None,
         )
         self.assertEqual(result, utils.dict_to_b64_string(expected))
 


### PR DESCRIPTION
### Summary:
This PR enhances the `task_result` function to include file reports and task reports, and adds a file filtering mechanism to `get_input_files` based on data type, MIME type, and filename using partial matching.

### Technical Details:
*   **Improve Task Results:** The `task_result` function in `openrelik_worker_common/utils.py` now accepts `file_reports` and `task_report` arguments. This allows tasks to provide more granular information about their execution, including specific reports for each file processed and an overall summary report for the task itself. This enhances the reporting capabilities and provides richer context for analyzing task outcomes.
*   **File Filtering:**  The `get_input_files` function now supports filtering input files based on `data_type`, `mime_type`, and `filename` using a new `filter` argument. This filter uses `fnmatch` for partial string matching, allowing for flexible and robust filtering based on patterns. This feature allows tasks to selectively process files based on specific criteria, improving efficiency and targeted processing. The  `filter_compatible_files` function implements this filtering logic.
*   **New `create_file_report` Function:** A new helper function, `create_file_report`, was added to facilitate the creation of standardized file report dictionaries.  This promotes consistency in reporting and simplifies the process of generating reports for individual files processed by a task.
*   **Command Parameter Made Optional:** The `command` parameter in the `task_result` function is now optional, reflecting cases where the command might not be relevant or available.



