### PR TITLE
Add more unit tests.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    # ignore all test cases in tests/
+    tests/*

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -21,4 +21,9 @@ jobs:
         poetry install --with test --no-root
     - name: Test with pytest - ${{ matrix.python-version }}
       run: |
-        poetry run pytest --cov=. -v
+        poetry run pytest --cov=. --cov-branch --cov-report=xml -v
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: openrelik/openrelik-worker-common

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/openrelik/openrelik-worker-common/graph/badge.svg?token=T0Z72PB3YL)](https://codecov.io/gh/openrelik/openrelik-worker-common)
+
 # openrelik-worker-common
 Common utilities for OpenRelik workers
 

--- a/openrelik_worker_common/archive_utils.py
+++ b/openrelik_worker_common/archive_utils.py
@@ -38,7 +38,7 @@ def extract_archive(input_file: dict, output_folder: str, log_file: str) -> str:
         raise RuntimeError("7z executable not found!")
 
     export_folder = os.path.join(output_folder, uuid4().hex)
-    os.mkdir(export_folder)
+    os.makedirs(export_folder)
 
     if input_filename.endswith((".tgz", ".tar.gz")):
         command = [

--- a/openrelik_worker_common/task_utils.py
+++ b/openrelik_worker_common/task_utils.py
@@ -105,17 +105,17 @@ def filter_compatible_files(input_files, filter_dict):
     for file_data in input_files:
         if file_data.get("data_type") is not None and any(
             fnmatch.fnmatch(file_data.get("data_type"), pattern)
-            for pattern in filter_dict.get("data_types")
+            for pattern in (filter_dict.get("data_types") or [])
         ):
             compatible_files.append(file_data)
         elif file_data.get("mime_type") is not None and any(
             fnmatch.fnmatch(file_data.get("mime_type"), pattern)
-            for pattern in filter_dict.get("mime_types")
+            for pattern in (filter_dict.get("mime_types") or [])
         ):
             compatible_files.append(file_data)
         elif file_data.get("display_name") is not None and any(
             fnmatch.fnmatch(file_data.get("display_name"), pattern)
-            for pattern in filter_dict.get("filenames")
+            for pattern in (filter_dict.get("filenames") or [])
         ):
             compatible_files.append(file_data)
     return compatible_files

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -7,7 +7,7 @@ import subprocess
 from uuid import uuid4
 
 
-class Utils(unittest.TestCase):
+class TestArchiveUtils(unittest.TestCase):
     output_folder = "/tmp"
     log_file = "/tmp/log.txt"
 

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from openrelik_worker_common.archive_utils import extract_archive
+import os
+import shutil
+import subprocess
+from uuid import uuid4
+
+
+class Utils(unittest.TestCase):
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_tgz(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        output_folder = "/tmp"
+        log_file = "/tmp/log.txt"
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(input_file, output_folder, log_file)
+        self.assertIn("tar -vxzf", result[0])
+        self.assertIn(output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_zip(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        input_file = {"path": "/path/to/archive.zip", "display_name": "archive.zip"}
+        output_folder = "/tmp"
+        log_file = "/tmp/log.txt"
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(input_file, output_folder, log_file)
+        self.assertIn("7z x", result[0])
+        self.assertIn(output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    def test_extract_archive_error(self, mock_check_output, mock_subprocess_call):
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        output_folder = "/tmp"
+        log_file = "/tmp/log.txt"
+        mock_subprocess_call.return_value = 1
+
+        with self.assertRaises(RuntimeError):
+            extract_archive(input_file, output_folder, log_file)
+
+    @patch("subprocess.check_output")
+    def test_extract_archive_7z_not_found(self, mock_check_output):
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        output_folder = "/tmp"
+        log_file = "/tmp/log.txt"
+        mock_check_output.return_value = b""
+
+        with patch("shutil.which", return_value=None):
+            with self.assertRaises(RuntimeError):
+                extract_archive(input_file, output_folder, log_file)
+
+    @patch("os.makedirs")
+    @patch("shutil.which")
+    def test_extract_archive_mkdir_error(self, mock_which, mock_makedirs):
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        output_folder = "/tmp"
+        log_file = "/tmp/log.txt"
+        mock_makedirs.side_effect = OSError("Mocked error")
+        mock_which.return_value = True
+
+        with self.assertRaises(OSError):
+            extract_archive(input_file, output_folder, log_file)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -8,6 +8,9 @@ from uuid import uuid4
 
 
 class Utils(unittest.TestCase):
+    output_folder = "/tmp"
+    log_file = "/tmp/log.txt"
+
     @patch("subprocess.call")
     @patch("subprocess.check_output")
     @patch("shutil.which")
@@ -15,15 +18,13 @@ class Utils(unittest.TestCase):
         self, mock_which, mock_check_output, mock_subprocess_call
     ):
         input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
-        output_folder = "/tmp"
-        log_file = "/tmp/log.txt"
         mock_check_output.return_value = b""
         mock_which.return_value = True
         mock_subprocess_call.return_value = 0
 
-        result = extract_archive(input_file, output_folder, log_file)
+        result = extract_archive(input_file, self.output_folder, self.log_file)
         self.assertIn("tar -vxzf", result[0])
-        self.assertIn(output_folder, result[1])
+        self.assertIn(self.output_folder, result[1])
 
     @patch("subprocess.call")
     @patch("subprocess.check_output")
@@ -32,49 +33,41 @@ class Utils(unittest.TestCase):
         self, mock_which, mock_check_output, mock_subprocess_call
     ):
         input_file = {"path": "/path/to/archive.zip", "display_name": "archive.zip"}
-        output_folder = "/tmp"
-        log_file = "/tmp/log.txt"
         mock_check_output.return_value = b""
         mock_which.return_value = True
         mock_subprocess_call.return_value = 0
 
-        result = extract_archive(input_file, output_folder, log_file)
+        result = extract_archive(input_file, self.output_folder, self.log_file)
         self.assertIn("7z x", result[0])
-        self.assertIn(output_folder, result[1])
+        self.assertIn(self.output_folder, result[1])
 
     @patch("subprocess.call")
     @patch("subprocess.check_output")
     def test_extract_archive_error(self, mock_check_output, mock_subprocess_call):
         input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
-        output_folder = "/tmp"
-        log_file = "/tmp/log.txt"
         mock_subprocess_call.return_value = 1
 
         with self.assertRaises(RuntimeError):
-            extract_archive(input_file, output_folder, log_file)
+            extract_archive(input_file, self.output_folder, self.log_file)
 
     @patch("subprocess.check_output")
     def test_extract_archive_7z_not_found(self, mock_check_output):
         input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
-        output_folder = "/tmp"
-        log_file = "/tmp/log.txt"
         mock_check_output.return_value = b""
 
         with patch("shutil.which", return_value=None):
             with self.assertRaises(RuntimeError):
-                extract_archive(input_file, output_folder, log_file)
+                extract_archive(input_file, self.output_folder, self.log_file)
 
     @patch("os.makedirs")
     @patch("shutil.which")
     def test_extract_archive_mkdir_error(self, mock_which, mock_makedirs):
         input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
-        output_folder = "/tmp"
-        log_file = "/tmp/log.txt"
         mock_makedirs.side_effect = OSError("Mocked error")
         mock_which.return_value = True
 
         with self.assertRaises(OSError):
-            extract_archive(input_file, output_folder, log_file)
+            extract_archive(input_file, self.output_folder, self.log_file)
 
 
 if __name__ == "__main__":

--- a/tests/test_debug_utils.py
+++ b/tests/test_debug_utils.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from openrelik_worker_common.debug_utils import start_debugger
+import os
+
+
+class TestStartDebugger(unittest.TestCase):
+    @patch("debugpy.listen")
+    def test_start_debugger_default_port(self, mock_listen):
+        start_debugger()
+        mock_listen.assert_called_once_with(("0.0.0.0", 5678))
+
+    @patch("debugpy.listen")
+    def test_start_debugger_custom_port(self, mock_listen):
+        start_debugger(port=1234)
+        mock_listen.assert_called_once_with(("0.0.0.0", 1234))
+
+    @patch("debugpy.listen")
+    @patch.dict("os.environ", {"OPENRELIK_PYDEBUG_PORT": "1234"})
+    def test_start_debugger_env_var_port(self, mock_listen):
+        start_debugger()
+        mock_listen.assert_called_once_with(("0.0.0.0", 1234))
+
+    @patch.dict("os.environ", {"OPENRELIK_PYDEBUG_PORT": "abc"})
+    def test_start_debugger_env_var_port_invalid(self):
+        with self.assertRaises(ValueError):
+            start_debugger()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_debug_utils.py
+++ b/tests/test_debug_utils.py
@@ -4,7 +4,7 @@ from openrelik_worker_common.debug_utils import start_debugger
 import os
 
 
-class TestStartDebugger(unittest.TestCase):
+class Utils(unittest.TestCase):
     @patch("debugpy.listen")
     def test_start_debugger_default_port(self, mock_listen):
         start_debugger()

--- a/tests/test_debug_utils.py
+++ b/tests/test_debug_utils.py
@@ -4,7 +4,7 @@ from openrelik_worker_common.debug_utils import start_debugger
 import os
 
 
-class Utils(unittest.TestCase):
+class TestDebugUtils(unittest.TestCase):
     @patch("debugpy.listen")
     def test_start_debugger_default_port(self, mock_listen):
         start_debugger()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,75 @@
+import unittest
+from openrelik_worker_common.reporting import (
+    MarkdownTable,
+    MarkdownDocument,
+    MarkdownDocumentSection,
+    Report,
+    Priority,
+)
+from unittest.mock import patch, MagicMock
+
+
+class TestMarkdownDocument(unittest.TestCase):
+    def test_markdown_document_init(self):
+        document = MarkdownDocument("Test Document")
+        self.assertEqual(document.title, "Test Document")
+        self.assertEqual(document.sections, [])
+
+    def test_markdown_document_add(self):
+        report = Report("Test Report")
+        report.summary = "Test Summary"
+        report.priority = Priority.LOW
+
+        document = MarkdownDocument("Test Title")
+        # document.title = "Test Title"
+        section = document.add_section()
+        section.add_header("Test Header", level=2)
+        section.add_bullet("Test Bullet", level=1)
+        section.add_code("Test Code")
+        section.add_code_block("Test Code Block")
+        section.add_blockquote("Test Blockquote")
+        section.add_paragraph(document.fmt.bold("Test Paragraph"))
+        section.add_horizontal_rule()
+        table = MarkdownTable(["column1", "column2"])
+        table.add_row(["row1", "row2"])
+        section.add_table(table)
+
+        with self.assertRaises(ValueError):
+            table.add_row(["row1", "row2", "rowthatshouldnotbehere"])
+
+        with self.assertRaises(ValueError):
+            section.fmt.heading(text="Test Header", level=999)
+
+        markdown = document.to_markdown()
+        self.assertIsInstance(section, MarkdownDocumentSection)
+        self.assertIn("# Test Title", markdown)
+        self.assertIn("## Test Header", markdown)
+        self.assertIn("## Test Header", markdown)
+        self.assertIn("* Test Bullet", markdown)
+        self.assertIn("`Test Code`", markdown)
+        self.assertIn("```\nTest Code Block\n```", markdown)
+        self.assertIn("> Test Blockquote", markdown)
+        self.assertIn("**Test Paragraph**", markdown)
+        self.assertIn("---", markdown)
+        self.assertIn("|column1|column2|", markdown)
+
+        json = report.to_json()
+        self.assertEqual(
+            json,
+            '{"title": "Test Report", "summary": "Test Summary", "content": "# Test Report\\n", "priority": 10}',
+        )
+
+    def test_markdown_document_to_markdown(self):
+        document = MarkdownDocument("Test Document")
+        markdown = document.to_markdown()
+        self.assertIn("# Test Document", markdown)
+
+
+class TestMarkdownDocumentSection(unittest.TestCase):
+    def test_markdown_document_section_init(self):
+        section = MarkdownDocumentSection()
+        self.assertEqual(section.content, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task_utils.py
+++ b/tests/test_task_utils.py
@@ -69,6 +69,91 @@ class Utils(unittest.TestCase):
         )
         self.assertEqual(result, task_utils.encode_dict_to_base64(expected))
 
+    input_files = [
+        {
+            "data_type": "image/jpeg",
+            "mime_type": "image/jpeg",
+            "display_name": "image.jpg",
+            "extension": "jpg",
+        },
+        {
+            "data_type": "text/plain",
+            "mime_type": "text/plain",
+            "display_name": "document.txt",
+            "extension": "txt",
+        },
+    ]
+
+    def test_filter_compatible_files_data_type_match(self):
+        filter_dict = {"data_types": ["image/*"]}
+        expected_result = [
+            {
+                "data_type": "image/jpeg",
+                "mime_type": "image/jpeg",
+                "display_name": "image.jpg",
+                "extension": "jpg",
+            },
+        ]
+        self.assertEqual(
+            task_utils.filter_compatible_files(self.input_files, filter_dict),
+            expected_result,
+        )
+
+    def test_filter_compatible_files_mime_type_match(self):
+        filter_dict = {"mime_types": ["text/*"]}
+        expected_result = [
+            {
+                "data_type": "text/plain",
+                "mime_type": "text/plain",
+                "display_name": "document.txt",
+                "extension": "txt",
+            },
+        ]
+        self.assertEqual(
+            task_utils.filter_compatible_files(self.input_files, filter_dict),
+            expected_result,
+        )
+
+    def test_filter_compatible_files_filename_match(self):
+        filter_dict = {"filenames": ["image.*"]}
+        expected_result = [
+            {
+                "data_type": "image/jpeg",
+                "mime_type": "image/jpeg",
+                "display_name": "image.jpg",
+                "extension": "jpg",
+            },
+        ]
+        self.assertEqual(
+            task_utils.filter_compatible_files(self.input_files, filter_dict),
+            expected_result,
+        )
+
+    def test_filter_compatible_files_no_match(self):
+        filter_dict = {"data_types": ["video/*"]}
+        expected_result = []
+        self.assertEqual(
+            task_utils.filter_compatible_files(self.input_files, filter_dict),
+            expected_result,
+        )
+
+    def test_filter_compatible_files_empty_input(self):
+        input_files = []
+        filter_dict = {"data_types": ["image/*"]}
+        expected_result = []
+        self.assertEqual(
+            task_utils.filter_compatible_files(input_files, filter_dict),
+            expected_result,
+        )
+
+    def test_filter_compatible_files_empty_filter(self):
+        filter_dict = {}
+        expected_result = []
+        self.assertEqual(
+            task_utils.filter_compatible_files(self.input_files, filter_dict),
+            expected_result,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds unit tests to:
* debug_utils
* archive_utils
* task_utils
* reporting

Configures codecov test coverage reports for repository.

```
---------- coverage: platform linux, python 3.12.3-final-0 -----------
Name                                       Stmts   Miss  Cover
--------------------------------------------------------------
openrelik_worker_common/__init__.py            0      0   100%
openrelik_worker_common/archive_utils.py      20      1    95%
openrelik_worker_common/debug_utils.py         7      0   100%
openrelik_worker_common/file_utils.py         55      1    98%
openrelik_worker_common/reporting.py         101      4    96%
openrelik_worker_common/task_utils.py         27      1    96%
--------------------------------------------------------------
TOTAL                                        210      7    97%
```
