### PR TITLE
Add file filtering to archive extraction

### DIFF
--- a/openrelik_worker_common/archive_utils.py
+++ b/openrelik_worker_common/archive_utils.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 
 
 def extract_archive(
-    input_file: dict, output_folder: str, log_file: str
+    input_file: dict, output_folder: str, log_file: str, file_filter: list = []
 ) -> tuple[str, str]:
     """Unpacks an archive.
 
@@ -28,6 +28,7 @@ def extract_archive(
       input_file(dict): Input file dict.
       output_folder(string): OpenRelik output_folder.
       log_file(string): Log file path.
+      file_filter(list): List of file patterns to extract (optional).
 
     Return:
       command(string): The executed command string.
@@ -50,6 +51,10 @@ def extract_archive(
             "-C",
             f"{export_folder}",
         ]
+        if file_filter:
+            command.extend(["--recursion", "--no-anchored"])
+            for pattern in file_filter:
+                command.extend(["--wildcards", pattern.strip()])
     else:
         command = [
             "7z",
@@ -57,6 +62,10 @@ def extract_archive(
             input_path,
             f"-o{export_folder}",
         ]
+        if file_filter:
+            command.append("-r")
+            for pattern in file_filter:
+                command.append(pattern.strip())
 
     command_string = " ".join(command)
     with open(log_file, "wb") as out:

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -26,6 +26,7 @@ class TestArchiveUtils(unittest.TestCase):
         result = extract_archive(
             input_file, self.output_folder, self.log_file, self.file_filter)
         self.assertIn("tar -vxzf", result[0])
+        self.assertIn("*.txt", result[0])
         self.assertIn(self.output_folder, result[1])
 
     @patch("subprocess.call")
@@ -42,6 +43,7 @@ class TestArchiveUtils(unittest.TestCase):
         result = extract_archive(
             input_file, self.output_folder, self.log_file, self.file_filter)
         self.assertIn("7z x", result[0])
+        self.assertIn("*.txt", result[0])
         self.assertIn(self.output_folder, result[1])
 
     @patch("subprocess.call")

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -32,6 +32,22 @@ class TestArchiveUtils(unittest.TestCase):
     @patch("subprocess.call")
     @patch("subprocess.check_output")
     @patch("shutil.which")
+    def test_extract_archive_tgz_no_filter(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(input_file, self.output_folder, self.log_file)
+        self.assertIn("tar -vxzf", result[0])
+        self.assertNotIn("--wildcards", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
     def test_extract_archive_zip(
         self, mock_which, mock_check_output, mock_subprocess_call
     ):
@@ -44,6 +60,23 @@ class TestArchiveUtils(unittest.TestCase):
             input_file, self.output_folder, self.log_file, self.file_filter)
         self.assertIn("7z x", result[0])
         self.assertIn("*.txt", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_zip_no_filter(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        input_file = {"path": "/path/to/archive.zip", "display_name": "archive.zip"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(input_file, self.output_folder, self.log_file)
+        self.assertIn("7z x", result[0])
+        self.assertNotIn("-r", result[0])
         self.assertIn(self.output_folder, result[1])
 
     @patch("subprocess.call")

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -24,7 +24,8 @@ class TestArchiveUtils(unittest.TestCase):
         mock_subprocess_call.return_value = 0
 
         result = extract_archive(
-            input_file, self.output_folder, self.log_file, self.file_filter)
+            input_file, self.output_folder, self.log_file, self.file_filter
+        )
         self.assertIn("tar -vxzf", result[0])
         self.assertIn("*.txt", result[0])
         self.assertIn(self.output_folder, result[1])
@@ -57,11 +58,11 @@ class TestArchiveUtils(unittest.TestCase):
         mock_subprocess_call.return_value = 0
 
         result = extract_archive(
-            input_file, self.output_folder, self.log_file, self.file_filter)
+            input_file, self.output_folder, self.log_file, self.file_filter
+        )
         self.assertIn("7z x", result[0])
         self.assertIn("*.txt", result[0])
         self.assertIn(self.output_folder, result[1])
-
 
     @patch("subprocess.call")
     @patch("subprocess.check_output")
@@ -86,8 +87,9 @@ class TestArchiveUtils(unittest.TestCase):
         mock_subprocess_call.return_value = 1
 
         with self.assertRaises(RuntimeError):
-            extract_archive(input_file, self.output_folder, self.log_file,
-                            self.file_filter)
+            extract_archive(
+                input_file, self.output_folder, self.log_file, self.file_filter
+            )
 
     @patch("subprocess.check_output")
     def test_extract_archive_7z_not_found(self, mock_check_output):
@@ -96,8 +98,9 @@ class TestArchiveUtils(unittest.TestCase):
 
         with patch("shutil.which", return_value=None):
             with self.assertRaises(RuntimeError):
-                extract_archive(input_file, self.output_folder, self.log_file,
-                                self.file_filter)
+                extract_archive(
+                    input_file, self.output_folder, self.log_file, self.file_filter
+                )
 
     @patch("os.makedirs")
     @patch("shutil.which")
@@ -107,8 +110,9 @@ class TestArchiveUtils(unittest.TestCase):
         mock_which.return_value = True
 
         with self.assertRaises(OSError):
-            extract_archive(input_file, self.output_folder, self.log_file,
-                            self.file_filter)
+            extract_archive(
+                input_file, self.output_folder, self.log_file, self.file_filter
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 class TestArchiveUtils(unittest.TestCase):
     output_folder = "/tmp"
     log_file = "/tmp/log.txt"
+    file_filter = ["*.txt", "*.evtx"]
 
     @patch("subprocess.call")
     @patch("subprocess.check_output")
@@ -22,7 +23,8 @@ class TestArchiveUtils(unittest.TestCase):
         mock_which.return_value = True
         mock_subprocess_call.return_value = 0
 
-        result = extract_archive(input_file, self.output_folder, self.log_file)
+        result = extract_archive(
+            input_file, self.output_folder, self.log_file, self.file_filter)
         self.assertIn("tar -vxzf", result[0])
         self.assertIn(self.output_folder, result[1])
 
@@ -37,7 +39,8 @@ class TestArchiveUtils(unittest.TestCase):
         mock_which.return_value = True
         mock_subprocess_call.return_value = 0
 
-        result = extract_archive(input_file, self.output_folder, self.log_file)
+        result = extract_archive(
+            input_file, self.output_folder, self.log_file, self.file_filter)
         self.assertIn("7z x", result[0])
         self.assertIn(self.output_folder, result[1])
 
@@ -48,7 +51,8 @@ class TestArchiveUtils(unittest.TestCase):
         mock_subprocess_call.return_value = 1
 
         with self.assertRaises(RuntimeError):
-            extract_archive(input_file, self.output_folder, self.log_file)
+            extract_archive(input_file, self.output_folder, self.log_file,
+                            self.file_filter)
 
     @patch("subprocess.check_output")
     def test_extract_archive_7z_not_found(self, mock_check_output):
@@ -57,7 +61,8 @@ class TestArchiveUtils(unittest.TestCase):
 
         with patch("shutil.which", return_value=None):
             with self.assertRaises(RuntimeError):
-                extract_archive(input_file, self.output_folder, self.log_file)
+                extract_archive(input_file, self.output_folder, self.log_file,
+                                self.file_filter)
 
     @patch("os.makedirs")
     @patch("shutil.which")
@@ -67,7 +72,8 @@ class TestArchiveUtils(unittest.TestCase):
         mock_which.return_value = True
 
         with self.assertRaises(OSError):
-            extract_archive(input_file, self.output_folder, self.log_file)
+            extract_archive(input_file, self.output_folder, self.log_file,
+                            self.file_filter)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
Introduces the ability to selectively extract files from archives based on a list of file patterns.

### Technical Details:
*   **Function Signature Modification:** The `extract_archive` function in `openrelik_worker_common/archive_utils.py` now accepts an optional `file_filter` argument, which is a list of file patterns.
*   **Conditional Extraction Logic:** The extraction command now conditionally includes file filtering options based on the presence of the `file_filter` list.
*   **`tar` command update**: When using the tar command an extension with recursion and no-anchored option were added, as well as the wildcards option to filter the files to be extracted.
*   **`7z` command update**: When using the 7z command the `-r` option has been added to enable recursion for extraction. In addition each pattern in the filter will be passed as an argument for the command.

fixes: #28 