### PR TITLE
Add checks to BlockDevice class to make sure required CLI tools are available.

### DIFF
--- a/openrelik_worker_common/mount_utils.py
+++ b/openrelik_worker_common/mount_utils.py
@@ -15,8 +15,10 @@
 import json
 import logging
 import os
+from shutil import which
 import subprocess
 from uuid import uuid4
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -52,6 +54,10 @@ class BlockDevice:
         self.mountpoints = []
         self.mountroot = "/mnt"
         self.supported_fstypes = ["dos", "xfs", "ext2", "ext3", "ext4", "ntfs", "vfat"]
+
+        (available, errmsg) = self._required_tools_available()
+        if not available:
+            raise RuntimeError(f"Error tools missing: {errmsg}")
 
         # Setup the loop device
         self.blkdevice = self._losetup()
@@ -96,6 +102,24 @@ class BlockDevice:
 
         return blkdevice
 
+    def _required_tools_available(self) -> tuple[bool, str]:
+        """Check if required cli tools are available.
+
+        Returns:
+            tuple: tuple of return bool and error message
+        """
+        errmsg = ""
+        ok = True
+
+        tools = ["lsblk", "blkid", "mount"]
+
+        for tool in tools:
+            if not which(tool):
+                errmsg += f" {tool} "
+                ok = False
+
+        return (ok, errmsg)
+
     def _blkinfo(self) -> dict:
         """Extract device and partition information using blkinfo.
 
@@ -139,7 +163,7 @@ class BlockDevice:
             # No partitions on this disk.
             return partitions
         for children in bd.get("children"):
-            partition = f"/dev/{children["name"]}"
+            partition = f"/dev/{children['name']}"
             if self._is_important_partition(children):
                 partitions.append(partition)
 
@@ -158,7 +182,7 @@ class BlockDevice:
         """
         if partition["size"] < self.min_partition_size:
             return False
-        fs_type = self._get_fstype(f"/dev/{partition["name"]}")
+        fs_type = self._get_fstype(f"/dev/{partition['name']}")
         if fs_type not in self.supported_fstypes:
             return False
 

--- a/openrelik_worker_common/mount_utils.py
+++ b/openrelik_worker_common/mount_utils.py
@@ -15,8 +15,9 @@
 import json
 import logging
 import os
-from shutil import which
 import subprocess
+
+from shutil import which
 from uuid import uuid4
 
 

--- a/tests/test_mount_utils.py
+++ b/tests/test_mount_utils.py
@@ -195,6 +195,7 @@ class Utils(unittest.TestCase):
         self.assertIn("lsblk", result[1])
         self.assertIn("blkid", result[1])
         self.assertIn("mount", result[1])
+        self.assertRaises(RuntimeError)
 
     @patch("openrelik_worker_common.mount_utils.which")
     def test_RequiredToolsAvailable__some_tools_available(self, mock_which):

--- a/tests/test_mount_utils.py
+++ b/tests/test_mount_utils.py
@@ -46,6 +46,12 @@ class Utils(unittest.TestCase):
             "{'blockdevices': [{'name': 'loop0', 'maj:min': '7:0', 'rm': False, 'size': 1048576, 'ro': False, 'type': 'loop', 'mountpoints': [None]}]}",
         )
 
+    @patch("openrelik_worker_common.mount_utils.which")
+    def test_BlkInfo_tools_not_available(self, mock_which):
+        mock_which.return_value = None
+        with self.assertRaises(RuntimeError):
+            bd = mount_utils.BlockDevice("./test_data/image_vfat.img")
+
     @patch("openrelik_worker_common.mount_utils.BlockDevice._losetup")
     @patch("openrelik_worker_common.mount_utils.subprocess.run")
     def test_BlkInfoError(self, mock_subprocess, mock_losetup):


### PR DESCRIPTION
Add checks to BlockDevice class to make sure required CLI tools are available, including unit tests.