### PR TITLE
Add Task Logs to Task Results

### DIFF
--- a/openrelik_worker_common/task_utils.py
+++ b/openrelik_worker_common/task_utils.py
@@ -30,9 +30,7 @@ def encode_dict_to_base64(dict_to_encode: dict) -> str:
     return base64.b64encode(json_string.encode("utf-8")).decode("utf-8")
 
 
-def get_input_files(
-    pipe_result: str, input_files: list[dict], filter: dict = None
-) -> list[dict]:
+def get_input_files(pipe_result: str, input_files: list[dict], filter: dict = None) -> list[dict]:
     """Prepares the input files for the task.
 
     Determines the appropriate input files by checking for results from a
@@ -62,6 +60,7 @@ def create_task_result(
     workflow_id: str,
     command: str = None,
     meta: dict = None,
+    task_logs: list[dict] = [],
     file_reports: list[dict] = [],
     task_report: dict = None,
 ) -> str:
@@ -72,6 +71,7 @@ def create_task_result(
         workflow_id: ID of the workflow.
         command: The command used to execute the task.
         meta: Additional metadata for the task (optional).
+        task_logs: List of task log file dictionaries.
         file_reports: List of file report dictionaries.
         task_report: A dictionary representing a task report.
 
@@ -83,6 +83,7 @@ def create_task_result(
         "workflow_id": workflow_id,
         "command": command,
         "meta": meta,
+        "task_logs": task_logs,
         "file_reports": file_reports,
         "task_report": task_report,
     }

--- a/tests/test_task_utils.py
+++ b/tests/test_task_utils.py
@@ -14,10 +14,8 @@
 
 import unittest
 import unittest.mock
-from pathlib import Path
 
-from openrelik_worker_common import task_utils
-from openrelik_worker_common import file_utils
+from openrelik_worker_common import file_utils, task_utils
 
 
 class Utils(unittest.TestCase):
@@ -55,6 +53,7 @@ class Utils(unittest.TestCase):
             "workflow_id": workflow_id,
             "command": command,
             "meta": meta,
+            "task_logs": [],
             "file_reports": [],
             "task_report": None,
         }
@@ -64,6 +63,7 @@ class Utils(unittest.TestCase):
             workflow_id=workflow_id,
             command=command,
             meta=meta,
+            task_logs=[],
             file_reports=[],
             task_report=None,
         )


### PR DESCRIPTION
### Summary
Adds `task_logs` to the task results to include log file information.

Task log files are currently handled as output files, but this can be unexpected as these will feed into any task that follows. For example, the archive extractor task extracts files, but will also output logfiles from the command operation.

This PR add an optional task_logs attribute to the task_result object that can save and map the log files but not send them to any following tasks.

### Technical Details:
*   **`create_task_result` Function Update:** The `create_task_result` function in `openrelik_worker_common/task_utils.py` now includes a `task_logs` parameter. This parameter is a list of dictionaries representing task log files.
*   **Task Result Payload:** The `task_logs` data is now included in the JSON payload generated by the `create_task_result` function. This allows task log file information to be passed along with other task results.