### PR TITLE
OpenRelik data_type code definitions.

### DIFF
--- a/openrelik_worker_common/data_types.py
+++ b/openrelik_worker_common/data_types.py
@@ -24,6 +24,6 @@ from enum import StrEnum
 
 
 class DataType(StrEnum):
-    DISK_IMAGE_QCOW = "file:diskimage:qcow"
-    DISK_IMAGE_RAW = "file:diskimage:raw"
+    FILE_DISKIMAGE_QCOW = "file:diskimage:qcow"
+    FILE_DISKIMAGE_RAW = "file:diskimage:raw"
     FILE_BINARY = "file:binary"

--- a/openrelik_worker_common/data_types.py
+++ b/openrelik_worker_common/data_types.py
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenRelik data types
+
+This file defines the OpenRelik data types that can be used for input and
+output files. The data types are defined as StrEnums which takes care of
+the interoparability between code and database through string comparision 
+instead of forcing Enum object comparision. This also makes sure we can
+use both Enum based comparision and string based glob filtering.
+"""
+
+from enum import StrEnum
+
+
+class DataType(StrEnum):
+    DISK_IMAGE_QCOW = "file:diskimage:qcow"
+    DISK_IMAGE_RAW = "file:diskimage:raw"
+    FILE_BINARY = "file:binary"

--- a/openrelik_worker_common/data_types.py
+++ b/openrelik_worker_common/data_types.py
@@ -15,15 +15,15 @@
 
 This file defines the OpenRelik data types that can be used for input and
 output files. The data types are defined as StrEnums which takes care of
-the interoparability between code and database through string comparision 
-instead of forcing Enum object comparision. This also makes sure we can
-use both Enum based comparision and string based glob filtering.
+the interoperability between code and database through string comparison 
+instead of forcing Enum object comparison. This also makes sure we can
+use both Enum based comparison and string based glob filtering.
 """
 
 from enum import StrEnum
 
 
 class DataType(StrEnum):
-    FILE_DISKIMAGE_QCOW = "file:diskimage:qcow"
-    FILE_DISKIMAGE_RAW = "file:diskimage:raw"
-    FILE_BINARY = "file:binary"
+    DISKIMAGE_QCOW = "diskimage:qcow"
+    DISKIMAGE_RAW = "diskimage:raw"
+    BINARY = "binary"

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -11,19 +11,19 @@ class TestDataTypes(unittest.TestCase):
 
     def test_datatype_str_comparision(self):
         """Test string comparison of data types."""
-        self.assertEqual(data_types.DataType.FILE_DISKIMAGE_QCOW, "file:diskimage:qcow")
+        self.assertEqual(data_types.DataType.DISKIMAGE_QCOW, "diskimage:qcow")
 
     def test_datatype_enum_comparision(self):
         """Test enum comparison of data types."""
-        test_enum = data_types.DataType.FILE_DISKIMAGE_QCOW
+        test_enum = data_types.DataType.DISKIMAGE_QCOW
         self.assertIsInstance(test_enum, Enum)
         self.assertIsInstance(test_enum, StrEnum)
 
     def test_datatype_filtering(self):
         """Test glob comparision of data types."""
         input_files = [
-            {"name": "testfile.qcow", "data_type": f"container_explorer:{data_types.DataType.FILE_DISKIMAGE_QCOW}"},
-            {"name": "testfile.bin", "data_type": f"hayabusa:{data_types.DataType.FILE_BINARY}"},
+            {"name": "testfile.qcow", "data_type": f"container_explorer:{data_types.DataType.DISKIMAGE_QCOW}"},
+            {"name": "testfile.bin", "data_type": f"hayabusa:{data_types.DataType.BINARY}"},
         ]
 
         filter_dict = {"data_types": ["*"]}
@@ -42,7 +42,7 @@ class TestDataTypes(unittest.TestCase):
         compatible = task_utils.filter_compatible_files(input_files, filter_dict)
         self.assertEqual(len(compatible), 1)
 
-        filter_dict = {"data_types": [f"*:{data_types.DataType.FILE_DISKIMAGE_QCOW}"]}
+        filter_dict = {"data_types": [f"*:{data_types.DataType.DISKIMAGE_QCOW}"]}
         compatible = task_utils.filter_compatible_files(input_files, filter_dict)
         self.assertEqual(len(compatible), 1)
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,5 +1,7 @@
 import unittest
 
+from enum import Enum, StrEnum
+
 from openrelik_worker_common import data_types
 from openrelik_worker_common import task_utils
 
@@ -10,6 +12,12 @@ class TestDataTypes(unittest.TestCase):
     def test_datatype_str_comparision(self):
         """Test string comparison of data types."""
         self.assertEqual(data_types.DataType.DISK_IMAGE_QCOW, "file:diskimage:qcow")
+
+    def test_datatype_enum_comparision(self):
+        """Test enum comparison of data types."""
+        test_enum = data_types.DataType.DISK_IMAGE_QCOW
+        self.assertIsInstance(test_enum, Enum)
+        self.assertIsInstance(test_enum, StrEnum)
 
     def test_datatype_filtering(self):
         """Test glob comparision of data types."""

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -42,6 +42,10 @@ class TestDataTypes(unittest.TestCase):
         compatible = task_utils.filter_compatible_files(input_files, filter_dict)
         self.assertEqual(len(compatible), 1)
 
+        filter_dict = {"data_types": [f"*:{data_types.DataType.DISK_IMAGE_QCOW}"]}
+        compatible = task_utils.filter_compatible_files(input_files, filter_dict)
+        self.assertEqual(len(compatible), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -11,18 +11,18 @@ class TestDataTypes(unittest.TestCase):
 
     def test_datatype_str_comparision(self):
         """Test string comparison of data types."""
-        self.assertEqual(data_types.DataType.DISK_IMAGE_QCOW, "file:diskimage:qcow")
+        self.assertEqual(data_types.DataType.FILE_DISKIMAGE_QCOW, "file:diskimage:qcow")
 
     def test_datatype_enum_comparision(self):
         """Test enum comparison of data types."""
-        test_enum = data_types.DataType.DISK_IMAGE_QCOW
+        test_enum = data_types.DataType.FILE_DISKIMAGE_QCOW
         self.assertIsInstance(test_enum, Enum)
         self.assertIsInstance(test_enum, StrEnum)
 
     def test_datatype_filtering(self):
         """Test glob comparision of data types."""
         input_files = [
-            {"name": "testfile.qcow", "data_type": f"container_explorer:{data_types.DataType.DISK_IMAGE_QCOW}"},
+            {"name": "testfile.qcow", "data_type": f"container_explorer:{data_types.DataType.FILE_DISKIMAGE_QCOW}"},
             {"name": "testfile.bin", "data_type": f"hayabusa:{data_types.DataType.FILE_BINARY}"},
         ]
 
@@ -42,7 +42,7 @@ class TestDataTypes(unittest.TestCase):
         compatible = task_utils.filter_compatible_files(input_files, filter_dict)
         self.assertEqual(len(compatible), 1)
 
-        filter_dict = {"data_types": [f"*:{data_types.DataType.DISK_IMAGE_QCOW}"]}
+        filter_dict = {"data_types": [f"*:{data_types.DataType.FILE_DISKIMAGE_QCOW}"]}
         compatible = task_utils.filter_compatible_files(input_files, filter_dict)
         self.assertEqual(len(compatible), 1)
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -22,8 +22,8 @@ class TestDataTypes(unittest.TestCase):
     def test_datatype_filtering(self):
         """Test glob comparision of data types."""
         input_files = [
-            {"name": "testfile.qcow", "data_type": "container_explorer:file:disk:qcow"},
-            {"name": "testfile.bin", "data_type": "hayabusa:file:binary"},
+            {"name": "testfile.qcow", "data_type": f"container_explorer:{data_types.DataType.DISK_IMAGE_QCOW}"},
+            {"name": "testfile.bin", "data_type": f"hayabusa:{data_types.DataType.FILE_BINARY}"},
         ]
 
         filter_dict = {"data_types": ["*"]}
@@ -34,7 +34,7 @@ class TestDataTypes(unittest.TestCase):
         compatible = task_utils.filter_compatible_files(input_files, filter_dict)
         self.assertEqual(len(compatible), 1)
 
-        filter_dict = {"data_types": ["*:disk:*"]}
+        filter_dict = {"data_types": ["*:diskimage:*"]}
         compatible = task_utils.filter_compatible_files(input_files, filter_dict)
         self.assertEqual(len(compatible), 1)
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,0 +1,39 @@
+import unittest
+
+from openrelik_worker_common import data_types
+from openrelik_worker_common import task_utils
+
+
+class TestDataTypes(unittest.TestCase):
+    """Test the OpenRelik data types."""
+
+    def test_datatype_str_comparision(self):
+        """Test string comparison of data types."""
+        self.assertEqual(data_types.DataType.DISK_IMAGE_QCOW, "file:diskimage:qcow")
+
+    def test_datatype_filtering(self):
+        """Test glob comparision of data types."""
+        input_files = [
+            {"name": "testfile.qcow", "data_type": "container_explorer:file:disk:qcow"},
+            {"name": "testfile.bin", "data_type": "hayabusa:file:binary"},
+        ]
+
+        filter_dict = {"data_types": ["*"]}
+        compatible = task_utils.filter_compatible_files(input_files, filter_dict)
+        self.assertEqual(len(compatible), 2)
+
+        filter_dict = {"data_types": ["container_explorer:*"]}
+        compatible = task_utils.filter_compatible_files(input_files, filter_dict)
+        self.assertEqual(len(compatible), 1)
+
+        filter_dict = {"data_types": ["*:disk:*"]}
+        compatible = task_utils.filter_compatible_files(input_files, filter_dict)
+        self.assertEqual(len(compatible), 1)
+
+        filter_dict = {"data_types": ["*:binary"]}
+        compatible = task_utils.filter_compatible_files(input_files, filter_dict)
+        self.assertEqual(len(compatible), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR create the first OpenRelik data_type definitions to be used in input/output file data_type creation.

* Defined as StrEnums.
* Compatible with string and enum comparision.
* Compatible with glob string filtering in the task_utils.filter_compatible_files function.
* 100% test coverage
* wrapped in class so we can override methods (e.g. __str__, __repl__) in the future if we want to change the string representation.