### PR TITLE
Changes to parameters in extract_archive

### DIFF
--- a/openrelik_worker_common/archive_utils.py
+++ b/openrelik_worker_common/archive_utils.py
@@ -20,7 +20,12 @@ from uuid import uuid4
 
 
 def extract_archive(
-    input_file: dict, output_folder: str, log_file: str, file_filter: list = [], archive_password: str | None = None
+    input_file: dict,
+    output_folder: str,
+    log_file: str,
+    file_filter: list = [],
+    archive_password: str | None = None,
+    ignore_prompts: bool = True,
 ) -> tuple[str, str]:
     """Unpacks an archive.
 
@@ -29,7 +34,8 @@ def extract_archive(
       output_folder(string): OpenRelik output_folder.
       log_file(string): Log file path.
       file_filter(list): List of file patterns to extract (optional).
-      archive_password(str | None): Password of the input archives (optional). 
+      archive_password(str | None): Password of the input archives (optional).
+      ignore_prompts(bool): Whether to ignore prompts during extraction (optional).
 
     Return:
       command(string): The executed command string.
@@ -66,6 +72,8 @@ def extract_archive(
             input_path,
             f"-o{export_folder}",
         ]
+        if ignore_prompts:
+            command.append("-y")
         if archive_password is not None:
             command.append(f"-p{archive_password}")
         if file_filter:

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -151,6 +151,72 @@ class TestArchiveUtils(unittest.TestCase):
                 input_file, self.output_folder, self.log_file, self.file_filter
             )
 
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_zip_ignore_prompts(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        input_file = {"path": "/path/to/archive.zip", "display_name": "archive.zip"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(
+            input_file,
+            self.output_folder,
+            self.log_file,
+            self.file_filter,
+            ignore_prompts=True,
+        )
+        self.assertIn("7z x", result[0])
+        self.assertIn(" -y", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_zip_no_ignore_prompts(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        input_file = {"path": "/path/to/archive.zip", "display_name": "archive.zip"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(
+            input_file,
+            self.output_folder,
+            self.log_file,
+            self.file_filter,
+            ignore_prompts=False,
+        )
+        self.assertIn("7z x", result[0])
+        self.assertNotIn(" -y", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_tgz_ignore_prompts_ignored(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(
+            input_file,
+            self.output_folder,
+            self.log_file,
+            self.file_filter,
+            ignore_prompts=True,
+        )
+        self.assertIn("tar -vxzf", result[0])
+        self.assertNotIn(" -y", result[0])
+        self.assertIn(self.output_folder, result[1])
+
     def test_malformed_input_file(self):
         input_file = {}
 


### PR DESCRIPTION
Adding an optional flag (default True) to ignore 7z prompts. This process runs unattended so any interruption for user input will result in an exit code different than 0, and the task will fail (e.g. if it asks to overwrite a file during decompression due to file name collisions).