### PR TITLE
Add new task_config parameter to skip file creation in db

### DIFF
--- a/openrelik_worker_common/task_utils.py
+++ b/openrelik_worker_common/task_utils.py
@@ -120,10 +120,9 @@ def create_task_result(
         skip_file_creation: If True, signals to the mediator that it should
             **not** create database entries for the files in `output_files`.
             The files are still included in the result so downstream workers
-            receive them, but they will not appear as first-class files in the
-            UI or the database. Useful for tasks that produce a large number
-            of intermediate files where per-file DB bookkeeping is undesirable.
-            Defaults to False.
+            receive them, but they will not appear in the UI or the database.
+            Useful for tasks that produce a large number of intermediate files
+            where per-file DB bookkeeping is undesirable. Defaults to False.
 
     Returns:
         A base64-encoded string representing the JSON serialization of the

--- a/openrelik_worker_common/task_utils.py
+++ b/openrelik_worker_common/task_utils.py
@@ -87,6 +87,7 @@ def create_task_result(
     meta: dict = None,
     file_reports: list[dict] = [],
     task_report: dict = None,
+    skip_file_creation: bool = False,
 ) -> str:
     """Create a task result dictionary and encode it to a base64 string.
 
@@ -116,6 +117,13 @@ def create_task_result(
         task_report: An optional `openrelik_worker_common.reporting.Report` dictionary representing a comprehensive report
             for the entire task. This report will be shown in the Web UI.
             Defaults to None.
+        skip_file_creation: If True, signals to the mediator that it should
+            **not** create database entries for the files in `output_files`.
+            The files are still included in the result so downstream workers
+            receive them, but they will not appear as first-class files in the
+            UI or the database. Useful for tasks that produce a large number
+            of intermediate files where per-file DB bookkeeping is undesirable.
+            Defaults to False.
 
     Returns:
         A base64-encoded string representing the JSON serialization of the
@@ -177,6 +185,7 @@ def create_task_result(
         "meta": meta,
         "file_reports": file_reports,
         "task_report": task_report,
+        "skip_file_creation": skip_file_creation,
     }
     return encode_dict_to_base64(result)
 

--- a/tests/test_task_utils.py
+++ b/tests/test_task_utils.py
@@ -56,6 +56,7 @@ class Utils(unittest.TestCase):
             "meta": meta,
             "file_reports": [],
             "task_report": None,
+            "skip_file_creation": False,
         }
 
         result = task_utils.create_task_result(
@@ -68,6 +69,19 @@ class Utils(unittest.TestCase):
             task_report=None,
         )
         self.assertEqual(result, task_utils.encode_dict_to_base64(expected))
+
+    def test_create_task_result_skip_file_creation(self):
+        """skip_file_creation should be forwarded into the encoded result."""
+        import base64
+        import json
+
+        encoded = task_utils.create_task_result(
+            output_files=[{"uuid": "abc"}],
+            workflow_id="wf1",
+            skip_file_creation=True,
+        )
+        decoded = json.loads(base64.b64decode(encoded.encode("utf-8")).decode("utf-8"))
+        self.assertTrue(decoded["skip_file_creation"])
 
     input_files = [
         {


### PR DESCRIPTION
Add new parameter to skip file entry creation in db when processing a large number of small files.