### PR TITLE
Implement exclusion switches for both tar and 7z.

### DIFF
--- a/openrelik_worker_common/archive_utils.py
+++ b/openrelik_worker_common/archive_utils.py
@@ -24,9 +24,9 @@ def extract_archive(
     output_folder: str,
     log_file: str,
     file_filter: list = [],
-    file_exclusion_filter: list = [],
     archive_password: str | None = None,
     ignore_prompts: bool = True,
+    file_exclusion_filter: list = [],
 ) -> tuple[str, str]:
     """Unpacks an archive.
 
@@ -35,9 +35,9 @@ def extract_archive(
       output_folder(string): OpenRelik output_folder.
       log_file(string): Log file path.
       file_filter(list): List of file patterns to extract (optional).
-      file_exclusion_filter(list): List of file patterns to exclude (optional).
       archive_password(str | None): Password of the input archives (optional).
       ignore_prompts(bool): Whether to ignore prompts during extraction (optional).
+      file_exclusion_filter(list): List of file patterns to exclude (optional).
 
     Return:
       command(string): The executed command string.

--- a/openrelik_worker_common/archive_utils.py
+++ b/openrelik_worker_common/archive_utils.py
@@ -24,6 +24,7 @@ def extract_archive(
     output_folder: str,
     log_file: str,
     file_filter: list = [],
+    file_exclusion_filter: list = [],
     archive_password: str | None = None,
     ignore_prompts: bool = True,
 ) -> tuple[str, str]:
@@ -34,6 +35,7 @@ def extract_archive(
       output_folder(string): OpenRelik output_folder.
       log_file(string): Log file path.
       file_filter(list): List of file patterns to extract (optional).
+      file_exclusion_filter(list): List of file patterns to exclude (optional).
       archive_password(str | None): Password of the input archives (optional).
       ignore_prompts(bool): Whether to ignore prompts during extraction (optional).
 
@@ -65,6 +67,9 @@ def extract_archive(
             command.extend(["--recursion", "--no-anchored"])
             for pattern in file_filter:
                 command.extend(["--wildcards", pattern.strip()])
+        if file_exclusion_filter:
+            for pattern in file_exclusion_filter:
+                command.append(f"--exclude={pattern.strip()}")
     else:
         command = [
             "7z",
@@ -76,6 +81,9 @@ def extract_archive(
             command.append("-y")
         if archive_password is not None:
             command.append(f"-p{archive_password}")
+        if file_exclusion_filter:
+            for pattern in file_exclusion_filter:
+                command.append(f"-xr!{pattern.strip()}")
         if file_filter:
             command.append("-r")
             for pattern in file_filter:

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -225,5 +225,134 @@ class TestArchiveUtils(unittest.TestCase):
                 input_file, self.output_folder, self.log_file, self.file_filter
             )
 
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_tgz_exclusion_filter(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        """Test that file_exclusion_filter applies --exclude flags for tar."""
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(
+            input_file,
+            self.output_folder,
+            self.log_file,
+            file_exclusion_filter=["*.log", "tmp/*"],
+        )
+        self.assertIn("tar -vxzf", result[0])
+        self.assertIn("--exclude=*.log", result[0])
+        self.assertIn("--exclude=tmp/*", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_tgz_no_exclusion_filter(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        """Test that no --exclude flags are added when file_exclusion_filter is empty."""
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(input_file, self.output_folder, self.log_file)
+        self.assertIn("tar -vxzf", result[0])
+        self.assertNotIn("--exclude=", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_zip_exclusion_filter(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        """Test that file_exclusion_filter applies -xr! flags for 7z."""
+        input_file = {"path": "/path/to/archive.zip", "display_name": "archive.zip"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(
+            input_file,
+            self.output_folder,
+            self.log_file,
+            file_exclusion_filter=["*.log", "secret/*"],
+        )
+        self.assertIn("7z x", result[0])
+        self.assertIn("-xr!*.log", result[0])
+        self.assertIn("-xr!secret/*", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_zip_no_exclusion_filter(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        """Test that no -xr! flags are added when file_exclusion_filter is empty."""
+        input_file = {"path": "/path/to/archive.zip", "display_name": "archive.zip"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(input_file, self.output_folder, self.log_file)
+        self.assertIn("7z x", result[0])
+        self.assertNotIn("-xr!", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_tgz_filter_and_exclusion_filter(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        """Test that file_filter and file_exclusion_filter work together for tar."""
+        input_file = {"path": "/path/to/archive.tgz", "display_name": "archive.tgz"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(
+            input_file,
+            self.output_folder,
+            self.log_file,
+            file_filter=["*.evtx"],
+            file_exclusion_filter=["*.log"],
+        )
+        self.assertIn("tar -vxzf", result[0])
+        self.assertIn("*.evtx", result[0])
+        self.assertIn("--exclude=*.log", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+    @patch("subprocess.call")
+    @patch("subprocess.check_output")
+    @patch("shutil.which")
+    def test_extract_archive_zip_filter_and_exclusion_filter(
+        self, mock_which, mock_check_output, mock_subprocess_call
+    ):
+        """Test that file_filter and file_exclusion_filter work together for 7z."""
+        input_file = {"path": "/path/to/archive.zip", "display_name": "archive.zip"}
+        mock_check_output.return_value = b""
+        mock_which.return_value = True
+        mock_subprocess_call.return_value = 0
+
+        result = extract_archive(
+            input_file,
+            self.output_folder,
+            self.log_file,
+            file_filter=["*.evtx"],
+            file_exclusion_filter=["*.log"],
+        )
+        self.assertIn("7z x", result[0])
+        self.assertIn("*.evtx", result[0])
+        self.assertIn("-xr!*.log", result[0])
+        self.assertIn(self.output_folder, result[1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add file/wildcard exclusion switches to the extract archive functionality. This is needed to give the users of the extraction worker the option to exclude files or patterns from archives when processing those in Relik (think 3000+ collected file archives from EDR systems).

* This PR implements both tar and 7z exclusions.
* Add unit test coverage for new functionality.