### PR TITLE
Add EWF disk image support to BlockDevice

### DIFF
--- a/openrelik_worker_common/file_utils.py
+++ b/openrelik_worker_common/file_utils.py
@@ -239,7 +239,7 @@ def is_disk_image(inputfile: dict) -> bool:
     Returns: bool
     Raises: RuntimeError
     """
-    disk_image_extensions = [".img", ".raw", ".dd", ".qcow3", ".qcow2", ".qcow"]
+    disk_image_extensions = [".img", ".raw", ".dd", ".qcow3", ".qcow2", ".qcow", ".e01", ".ex01"]
 
     if "display_name" not in inputfile:
         raise RuntimeError("inputfile parameter malformed, no display_name found")

--- a/openrelik_worker_common/mount_utils.py
+++ b/openrelik_worker_common/mount_utils.py
@@ -20,6 +20,7 @@ import redis
 import shutil
 import socket
 import subprocess
+import tempfile
 import time
 
 from uuid import uuid4
@@ -67,6 +68,7 @@ class BlockDevice:
             min_partition_size (int): minimum partition size, default MIN_PARTITION_SIZE_BYTES
             max_mountpath_size (int): maximum root mount path length, default MAX_MOUNTPATH_SIZE
         """
+        self.original_image_path = image_path
         self.image_path = image_path
         self.min_partition_size = min_partition_size
         self.blkdevice = None
@@ -75,8 +77,10 @@ class BlockDevice:
         self.mountpoints = []
         self.mountroot = "/mnt"
         self.max_mountpath_size = max_mountpath_size
-        self.supported_fstypes = ["dos", "xfs", "ext2", "ext3", "ext4", "ntfs", "vfat"]
+        self.supported_fstypes = ["dos", "xfs", "ext2", "ext3", "ext4", "ntfs", "vfat", "btrfs"]
         self.supported_qcowtypes = ["qcow3", "qcow2", "qcow"]
+        self.supported_ewftypes = ["e01", "ex01"]
+        self.ewf_mount_path = None
 
         self.REDIS_URL = os.getenv("REDIS_URL") or "redis://localhost:6379/0"
         self.redis_client = None
@@ -102,22 +106,51 @@ class BlockDevice:
         # Check if required tools are available
         self._required_tools_available()
 
-        # Check the required kernel modules are available
-        self._required_modules_loaded()
-
         # Setup the block device
-        ext = image_path.suffix.strip(".")
-        if ext.lower() in self.supported_qcowtypes:
-            self.redis_client = redis.Redis.from_url(self.REDIS_URL)
-            self.blkdevice = self._nbdsetup()
-        else:
-            self.blkdevice = self._losetup()
+        ext = image_path.suffix.strip(".").lower()
+        try:
+            if ext in self.supported_ewftypes:
+                self.image_path = self._ewfmount()
+                image_path = pathlib.Path(self.image_path)
+                ext = image_path.suffix.strip(".").lower()
 
-        # Parse block device info
-        self.blkdeviceinfo = self._blkinfo()
+            if ext in self.supported_qcowtypes:
+                # Check required kernel modules only for disk image formats that use NBD.
+                self._required_modules_loaded()
+                self.redis_client = redis.Redis.from_url(self.REDIS_URL)
+                self.blkdevice = self._nbdsetup()
+            else:
+                self.blkdevice = self._losetup()
 
-        # Parse partition information
-        self.partitions = self._parse_partitions()
+            # Parse block device info
+            self.blkdeviceinfo = self._blkinfo()
+
+            # Parse partition information
+            self.partitions = self._parse_partitions()
+        except Exception:
+            if self.blkdevice:
+                try:
+                    self._detach_device()
+                except RuntimeError as cleanup_error:
+                    logger.error(
+                        f"Error detaching block device after setup failure: {cleanup_error}"
+                    )
+            if self.ewf_mount_path:
+                try:
+                    self._ewfumount()
+                except RuntimeError as cleanup_error:
+                    logger.error(
+                        f"Error cleaning up EWF mount after setup failure: {cleanup_error}"
+                    )
+            if self.redis_lock:
+                try:
+                    self.redis_lock.release()
+                    self.redis_lock = None
+                except Exception as cleanup_error:
+                    logger.error(
+                        f"Error releasing Redis lock after setup failure: {cleanup_error}"
+                    )
+            raise
 
     def _losetup(self) -> str:
         """Map image file to loopback device using losetup.
@@ -258,6 +291,78 @@ class BlockDevice:
             )
 
         return self.blkdevice
+
+    def _ewfmount(self) -> str:
+        """Mount an EWF image and return the raw ewf1 image path.
+
+        Returns:
+            str: raw image path exposed by ewfmount.
+
+        Raises:
+            RuntimeError: if ewfmount is not available or fails.
+        """
+        if not shutil.which("ewfmount"):
+            raise RuntimeError(
+                "Missing required tool: ewfmount. Make sure ewf-tools is installed!"
+            )
+
+        self.ewf_mount_path = tempfile.mkdtemp(
+            prefix="openrelik-ewf-", dir=self.mountroot
+        )
+        process = subprocess.run(
+            ["ewfmount", self.image_path, self.ewf_mount_path],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        if process.returncode != 0:
+            shutil.rmtree(self.ewf_mount_path, ignore_errors=True)
+            self.ewf_mount_path = None
+            raise RuntimeError(
+                "ewfmount failed for "
+                f"{self.image_path}: {process.stderr} {process.stdout}"
+            )
+
+        raw_image_path = os.path.join(self.ewf_mount_path, "ewf1")
+        if not os.path.exists(raw_image_path):
+            self._ewfumount()
+            raise RuntimeError(
+                f"ewfmount did not expose expected raw image: {raw_image_path}"
+            )
+
+        logger.info(f"ewfmount: success mounting {self.image_path}")
+        return raw_image_path
+
+    def _ewfumount(self) -> None:
+        """Unmount an EWF FUSE mount and remove its mount directory."""
+        if not self.ewf_mount_path:
+            return
+
+        unmount_commands = [
+            ["fusermount3", "-u", self.ewf_mount_path],
+            ["fusermount3", "-u", "-z", self.ewf_mount_path],
+            ["fusermount", "-u", self.ewf_mount_path],
+            ["fusermount", "-u", "-z", self.ewf_mount_path],
+            ["sudo", "umount", self.ewf_mount_path],
+            ["sudo", "umount", "-l", self.ewf_mount_path],
+        ]
+
+        last_error = ""
+        time.sleep(0.2)
+        for command in unmount_commands:
+            if not shutil.which(command[0]):
+                continue
+
+            process = subprocess.run(command, capture_output=True, check=False, text=True)
+            if process.returncode == 0:
+                logger.info(f"ewfmount: success unmounting {self.ewf_mount_path}")
+                shutil.rmtree(self.ewf_mount_path, ignore_errors=True)
+                self.ewf_mount_path = None
+                return
+            last_error = f"{process.stderr} {process.stdout}"
+
+        mount_path = self.ewf_mount_path
+        raise RuntimeError(f"Error unmounting EWF image mount {mount_path}: {last_error}")
 
     def _required_modules_loaded(self) -> None:
         """Checks if a required kernel module is loaded.
@@ -583,7 +688,10 @@ class BlockDevice:
                           detaching the block device fails.
         """
         self._umount_all()
-        self._detach_device()
+        if self.blkdevice:
+            self._detach_device()
+        if self.ewf_mount_path:
+            self._ewfumount()
         if self.redis_lock:
             self.redis_lock.release()
             logger.info(f"Redis lock released: {self.redis_lock.name}")

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -192,6 +192,8 @@ class Utils(unittest.TestCase):
         # Test that extensions are case-insensitive
         self.assertTrue(file_utils.is_disk_image({"display_name": "data.RAW"}))
         self.assertTrue(file_utils.is_disk_image({"display_name": "disk.DD"}))
+        self.assertTrue(file_utils.is_disk_image({"display_name": "evidence.E01"}))
+        self.assertTrue(file_utils.is_disk_image({"display_name": "evidence.EX01"}))
 
     def test_non_disk_image_extensions(self):
         # Test with common file extensions that are not disk images

--- a/tests/test_mount_utils.py
+++ b/tests/test_mount_utils.py
@@ -25,6 +25,7 @@ class Utils(unittest.TestCase):
     """Test the mount utils functions."""
 
     mountroot = "./mnt"
+    ewf_image_path = "/mock/evidence.E01"
     redis_client = None
 
     @classmethod
@@ -231,6 +232,231 @@ class Utils(unittest.TestCase):
             str(e.exception),
             "Error running qemu-nbd: None not a qcow file",
         )
+
+    @patch.object(mount_utils.BlockDevice, "_parse_partitions")
+    @patch.object(mount_utils.BlockDevice, "_blkinfo")
+    @patch.object(mount_utils.BlockDevice, "_losetup")
+    @patch.object(mount_utils.BlockDevice, "_required_modules_loaded")
+    @patch.object(mount_utils.BlockDevice, "_required_tools_available")
+    @patch.object(mount_utils.BlockDevice, "_ewfmount")
+    @patch("openrelik_worker_common.mount_utils.pathlib.Path.exists")
+    def test_EwfSetupUsesLoopDeviceWithoutNbdModuleCheck(
+        self,
+        mock_path_exists,
+        mock_ewfmount,
+        mock_tools,
+        mock_modules,
+        mock_losetup,
+        mock_blkinfo,
+        mock_parse_partitions,
+    ):
+        mock_path_exists.return_value = True
+        mock_ewfmount.return_value = "/mnt/openrelik-ewf-test/ewf1"
+        mock_losetup.return_value = "/dev/loop0"
+        mock_blkinfo.return_value = {"blockdevices": []}
+        mock_parse_partitions.return_value = []
+
+        bd = mount_utils.BlockDevice(self.ewf_image_path)
+        bd.setup()
+
+        mock_ewfmount.assert_called_once_with()
+        mock_modules.assert_not_called()
+        mock_losetup.assert_called_once_with()
+        self.assertEqual(bd.original_image_path, self.ewf_image_path)
+        self.assertEqual(bd.image_path, "/mnt/openrelik-ewf-test/ewf1")
+        self.assertEqual(bd.blkdevice, "/dev/loop0")
+
+    @patch.object(mount_utils.BlockDevice, "_ewfumount")
+    @patch.object(mount_utils.BlockDevice, "_losetup")
+    @patch.object(mount_utils.BlockDevice, "_required_tools_available")
+    @patch.object(mount_utils.BlockDevice, "_ewfmount")
+    @patch("openrelik_worker_common.mount_utils.pathlib.Path.exists")
+    def test_EwfSetupCleansUpEwfMountOnFailure(
+        self,
+        mock_path_exists,
+        mock_ewfmount,
+        mock_tools,
+        mock_losetup,
+        mock_ewfumount,
+    ):
+        mock_path_exists.return_value = True
+        mock_losetup.side_effect = RuntimeError("losetup failed")
+
+        bd = mount_utils.BlockDevice(self.ewf_image_path)
+
+        def _ewfmount():
+            bd.ewf_mount_path = "/mnt/openrelik-ewf-test"
+            return "/mnt/openrelik-ewf-test/ewf1"
+
+        mock_ewfmount.side_effect = _ewfmount
+
+        with self.assertRaises(RuntimeError) as e:
+            bd.setup()
+
+        self.assertEqual(str(e.exception), "losetup failed")
+        mock_ewfumount.assert_called_once_with()
+
+    @patch.object(mount_utils.BlockDevice, "_ewfumount")
+    @patch.object(mount_utils.BlockDevice, "_detach_device")
+    @patch.object(mount_utils.BlockDevice, "_parse_partitions")
+    @patch.object(mount_utils.BlockDevice, "_blkinfo")
+    @patch.object(mount_utils.BlockDevice, "_losetup")
+    @patch.object(mount_utils.BlockDevice, "_required_tools_available")
+    @patch.object(mount_utils.BlockDevice, "_ewfmount")
+    @patch("openrelik_worker_common.mount_utils.pathlib.Path.exists")
+    def test_EwfSetupCleansUpBlockDeviceAndEwfMountOnFailure(
+        self,
+        mock_path_exists,
+        mock_ewfmount,
+        mock_tools,
+        mock_losetup,
+        mock_blkinfo,
+        mock_parse_partitions,
+        mock_detach_device,
+        mock_ewfumount,
+    ):
+        mock_path_exists.return_value = True
+        mock_losetup.return_value = "/dev/loop0"
+        mock_blkinfo.side_effect = RuntimeError("lsblk failed")
+
+        bd = mount_utils.BlockDevice(self.ewf_image_path)
+
+        def _ewfmount():
+            bd.ewf_mount_path = "/mnt/openrelik-ewf-test"
+            return "/mnt/openrelik-ewf-test/ewf1"
+
+        mock_ewfmount.side_effect = _ewfmount
+
+        with self.assertRaises(RuntimeError) as e:
+            bd.setup()
+
+        self.assertEqual(str(e.exception), "lsblk failed")
+        mock_detach_device.assert_called_once_with()
+        mock_ewfumount.assert_called_once_with()
+        mock_parse_partitions.assert_not_called()
+
+    @patch.object(mount_utils.BlockDevice, "_ewfumount")
+    @patch.object(mount_utils.BlockDevice, "_losetup")
+    @patch.object(mount_utils.BlockDevice, "_required_tools_available")
+    @patch.object(mount_utils.BlockDevice, "_ewfmount")
+    @patch("openrelik_worker_common.mount_utils.pathlib.Path.exists")
+    def test_EwfSetupReportsOriginalErrorWhenCleanupFails(
+        self,
+        mock_path_exists,
+        mock_ewfmount,
+        mock_tools,
+        mock_losetup,
+        mock_ewfumount,
+    ):
+        mock_path_exists.return_value = True
+        mock_losetup.side_effect = RuntimeError("losetup failed")
+        mock_ewfumount.side_effect = RuntimeError("cleanup failed")
+
+        bd = mount_utils.BlockDevice(self.ewf_image_path)
+
+        def _ewfmount():
+            bd.ewf_mount_path = "/mnt/openrelik-ewf-test"
+            return "/mnt/openrelik-ewf-test/ewf1"
+
+        mock_ewfmount.side_effect = _ewfmount
+
+        with self.assertLogs("openrelik_worker_common.mount_utils", level="ERROR"):
+            with self.assertRaises(RuntimeError) as e:
+                bd.setup()
+
+        self.assertEqual(str(e.exception), "losetup failed")
+        mock_ewfumount.assert_called_once_with()
+
+    @patch("openrelik_worker_common.mount_utils.tempfile.mkdtemp")
+    @patch("openrelik_worker_common.mount_utils.shutil.which")
+    @patch("openrelik_worker_common.mount_utils.subprocess.run")
+    @patch("openrelik_worker_common.mount_utils.os.path.exists")
+    def test_EwfMountUsesMountroot(
+        self, mock_exists, mock_subprocess, mock_which, mock_mkdtemp
+    ):
+        mock_which.return_value = "/usr/bin/ewfmount"
+        mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], stdout="", stderr="", returncode=0
+        )
+        mock_mkdtemp.return_value = "/custom-mnt/openrelik-ewf-test"
+        mock_exists.return_value = True
+
+        bd = mount_utils.BlockDevice(self.ewf_image_path)
+        bd.mountroot = "/custom-mnt"
+        raw_image_path = bd._ewfmount()
+
+        mock_mkdtemp.assert_called_once_with(
+            prefix="openrelik-ewf-", dir="/custom-mnt"
+        )
+        self.assertEqual(raw_image_path, "/custom-mnt/openrelik-ewf-test/ewf1")
+
+    @patch("openrelik_worker_common.mount_utils.shutil.rmtree")
+    @patch("openrelik_worker_common.mount_utils.time.sleep")
+    @patch("openrelik_worker_common.mount_utils.subprocess.run")
+    @patch("openrelik_worker_common.mount_utils.shutil.which")
+    def test_EwfUmountKeepsMountPathOnFailure(
+        self, mock_which, mock_subprocess, mock_sleep, mock_rmtree
+    ):
+        mock_which.return_value = "/usr/bin/tool"
+        mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], stdout="", stderr="target is busy", returncode=1
+        )
+
+        bd = mount_utils.BlockDevice(self.ewf_image_path)
+        bd.ewf_mount_path = "/mnt/openrelik-ewf-test"
+
+        with self.assertRaises(RuntimeError) as e:
+            bd._ewfumount()
+
+        self.assertIn("Error unmounting EWF image mount", str(e.exception))
+        self.assertEqual(bd.ewf_mount_path, "/mnt/openrelik-ewf-test")
+        mock_sleep.assert_called_once_with(0.2)
+        mock_rmtree.assert_not_called()
+
+    @patch.object(mount_utils.BlockDevice, "_parse_partitions")
+    @patch.object(mount_utils.BlockDevice, "_blkinfo")
+    @patch.object(mount_utils.BlockDevice, "_nbdsetup")
+    @patch.object(mount_utils.BlockDevice, "_required_modules_loaded")
+    @patch.object(mount_utils.BlockDevice, "_required_tools_available")
+    @patch("openrelik_worker_common.mount_utils.redis.Redis.from_url")
+    @patch("openrelik_worker_common.mount_utils.pathlib.Path.exists")
+    def test_QcowSetupChecksNbdModule(
+        self,
+        mock_path_exists,
+        mock_redis,
+        mock_tools,
+        mock_modules,
+        mock_nbdsetup,
+        mock_blkinfo,
+        mock_parse_partitions,
+    ):
+        mock_path_exists.return_value = True
+        mock_nbdsetup.return_value = "/dev/nbd0"
+        mock_blkinfo.return_value = {"blockdevices": []}
+        mock_parse_partitions.return_value = []
+
+        bd = mount_utils.BlockDevice("./test_data/image_with_partitions.qcow2")
+        bd.setup()
+
+        mock_modules.assert_called_once_with()
+        mock_nbdsetup.assert_called_once_with()
+        self.assertEqual(bd.blkdevice, "/dev/nbd0")
+
+    @patch.object(mount_utils.BlockDevice, "_ewfumount")
+    @patch.object(mount_utils.BlockDevice, "_detach_device")
+    @patch.object(mount_utils.BlockDevice, "_umount_all")
+    def test_UmountCleansUpEwfMount(
+        self, mock_umount_all, mock_detach_device, mock_ewfumount
+    ):
+        bd = mount_utils.BlockDevice(self.ewf_image_path)
+        bd.blkdevice = "/dev/loop0"
+        bd.ewf_mount_path = "/mnt/openrelik-ewf-test"
+
+        bd.umount()
+
+        mock_umount_all.assert_called_once_with()
+        mock_detach_device.assert_called_once_with()
+        mock_ewfumount.assert_called_once_with()
 
     @patch.object(mount_utils.BlockDevice, "_is_important_partition")
     def test_MountWithNonExistingPartition(self, mock_important):


### PR DESCRIPTION
Adds EWF disk image support

This will allow workers that use BlockDevice to handle .E01 and .EX01 images through the existing disk image mounting flow.

- Detect .E01 and .EX01 as disk image.
- Mount EWF images with ewfmount and pass the exposed ewf1 raw image into the existing loop device flow.
- Keep the original image path available as original_image_path.
- Only check the nbd kernel module for qcow images.
- Add btrfs to supported filesystem types.
- Clean up partial EWF mounts, block devices, and Redis locks if setup fails.

Feedback is very welcome.