### PR TITLE
Aggregate output files across multiple piped results in get_input_files

### DIFF
--- a/openrelik_worker_common/task_utils.py
+++ b/openrelik_worker_common/task_utils.py
@@ -68,10 +68,18 @@ def get_input_files(
     if isinstance(pipe_result, str):
         pipe_results.append(pipe_result)
 
-    for pipe_result in pipe_results:
-        result_string = base64.b64decode(pipe_result.encode("utf-8")).decode("utf-8")
-        result_dict = json.loads(result_string)
-        input_files = result_dict.get("output_files", [])
+    def _decode(encoded_result: str) -> dict:
+        result_string = base64.b64decode(encoded_result.encode("utf-8")).decode("utf-8")
+        return json.loads(result_string)
+
+    if len(pipe_results) == 1:
+        input_files = _decode(pipe_results[0]).get("output_files", [])
+    elif pipe_results:
+        # Multiple piped results (e.g. a task downstream of a group): collect
+        # every branch's output files instead of keeping only the last one.
+        input_files = []
+        for encoded_result in pipe_results:
+            input_files.extend(_decode(encoded_result).get("output_files", []))
 
     if filter:
         input_files = filter_compatible_files(input_files, filter)

--- a/tests/test_task_utils.py
+++ b/tests/test_task_utils.py
@@ -41,6 +41,16 @@ class Utils(unittest.TestCase):
         expected = "/test/test"
         self.assertEqual(result, expected)
 
+    def test_get_input_files_multiple_pipes(self):
+        """Test get_input_files aggregates output files across pipe results."""
+        first = task_utils.encode_dict_to_base64({"output_files": [{"path": "/a"}]})
+        second = task_utils.encode_dict_to_base64({"output_files": [{"path": "/b"}]})
+
+        result = task_utils.get_input_files(
+            pipe_result=[first, second], input_files=None
+        )
+        self.assertEqual(result, [{"path": "/a"}, {"path": "/b"}])
+
     def test_create_task_result(self):
         """Test create_task_result function."""
         output_files = ["a", "b"]

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "openrelik-worker-common"
-version = "0.17.1"
+version = "0.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "debugpy" },


### PR DESCRIPTION
## Summary

`get_input_files` iterates the piped results from previous Celery tasks, but assigns `input_files` inside the loop instead of accumulating — so a task that receives multiple piped results (e.g. the callback of a group/chord, or any fan-in topology) only sees the **last** branch's output files. All other branches' outputs are silently dropped, which makes multi-branch workflows that join into a common downstream task (enrich -> join -> report) lose data without any error.

This change collects `output_files` across all piped results. The single-pipe-result path is byte-for-byte unchanged, so existing workers see no behavior difference; only the previously-broken multi-result case changes.

## Testing

New unit test covering two piped results aggregating in order; existing `get_input_files` tests (single pipe result, plain input files) pass unchanged. Verified in a live deployment with a workflow where two enrichment branches feed one downstream task: before, the join task received only the second branch's files; after, it receives both.
